### PR TITLE
Fixes a crash when this doesn't have a dir attribute.  Here attr('dir') w

### DIFF
--- a/js/jquery.tagedit-1.2.0.js
+++ b/js/jquery.tagedit-1.2.0.js
@@ -87,7 +87,8 @@
 		}
 
 		// Set the direction of the inputs
-		if(this.attr('dir').length > 0) {
+		var direction= this.attr('dir');
+		if(direction && direction.length > 0) {
 			options.direction = this.attr('dir');
 		}
 


### PR DESCRIPTION
Fixes a crash when this doesn't have a dir attribute.  Here attr('dir') was returning undefined, and crashing on the length accessor.

Signed-off-by: Steven Black steveb@stevenblack.com
