### PR TITLE
Fix autocomplete when source is a flat array

### DIFF
--- a/js/jquery.tagedit.js
+++ b/js/jquery.tagedit.js
@@ -167,9 +167,9 @@
 							var checkAutocomplete = oldValue == true? false : true;
 							// check if the Value ist new
 							var isNewResult = isNew($(this).val(), checkAutocomplete);
-							if(isNewResult[0] === true || (isNewResult[0] === false && typeof isNewResult[1] == 'string')) {
+							if(isNewResult[0] === true || isNewResult[1] != null) {
 
-								if(oldValue == false && typeof isNewResult[1] == 'string') {
+								if(oldValue == false && isNewResult[1] != null) {
 									oldValue = true;
 									id = isNewResult[1];
 								}
@@ -446,7 +446,7 @@
                     var label = options.checkNewEntriesCaseSensitive == true? result[i].label : result[i].label.toLowerCase();
 					if (label == compareValue) {
 						isNew = false;
-						autoCompleteId = result[i].id;
+						autoCompleteId = typeof result[i] == 'string' ? i : result[i].id;
 						break;
 					}
 				}


### PR DESCRIPTION
Fix autocomplete when source is a flat array e.g. ["tag1", "tag2"],
not an object with id and label items. In such case tag id is a number
not a string.
